### PR TITLE
fix(ci): enable coverage badge generation on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches-ignore: [ main, develop ]
+    branches-ignore: [ develop ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## Summary

- Remove `main` from `branches-ignore` in `test.yml` so the workflow fires on pushes to `main` (i.e. PR merges)
- The `coverage-badge` job already has `if: github.ref == 'refs/heads/main'` — it was simply never triggered because the workflow excluded `main` from its push trigger
- On merge, the badge SVG will be pushed to the `badges` branch, making the README coverage badge functional

## Side effect

Tests run twice on merge (once during the PR check, once post-merge). This is a minor and acceptable trade-off.